### PR TITLE
fix: force zh-TW output for non-Chinese URLs (Japanese articles came …

### DIFF
--- a/loader/langtools.py
+++ b/loader/langtools.py
@@ -27,6 +27,25 @@ VERTEX_PROJECT = os.getenv('GOOGLE_CLOUD_PROJECT')
 VERTEX_LOCATION = os.getenv('GOOGLE_CLOUD_LOCATION', 'global')
 
 
+# 輸出語言的硬約束。
+#
+# 為什麼需要它：prompt 內文寫「用繁體中文」不夠力——當原文是日文/英文長文時，
+# 那句指示會被夾在數千 token 的外語內容之前，模型會跟著原文語言作答。
+# system_instruction 位置無關、優先權高，才鎖得住輸出語言。
+# 另外這裡明講「跨語言」規則：原本所有 prompt 都只說「用繁體中文」，
+# 從沒說過「原文是別的語言時要翻過來」，模型自然把原文語言當成預設輸出語言。
+OUTPUT_LANGUAGE_INSTRUCTION = """你只用台灣用語的繁體中文寫作。
+
+不論輸入的文章是什麼語言（日文、英文、韓文、簡體中文等），所有輸出欄位一律改寫成
+台灣用語的繁體中文，絕對不要沿用原文的語言作答，也不要中日文或中英文混雜。
+
+人名、公司名、產品名、專有技術名詞可保留原文寫法，其餘內容一律翻成繁體中文。
+
+不要把日文漢字詞直接當中文用（例：「掲示板」寫成「公布欄／論壇」、「対応」寫成「因應」、
+「取組」寫成「作法」、「情報」寫成「資訊」）。也不要用簡體字或中國用語。
+標點使用全形，用字遵循台灣習慣（例：影片、品質、資訊、網路、軟體、預設）。"""
+
+
 def _get_vertex_client():
     """Get Vertex AI client instance"""
     if not GENAI_AVAILABLE:
@@ -40,6 +59,149 @@ def _get_vertex_client():
         location=VERTEX_LOCATION,
         http_options=types.HttpOptions(api_version="v1")
     )
+
+
+# 正規化階段的 prompt。
+#
+# 為什麼是「重點筆記」而不是「忠實翻譯」：實測過忠實翻譯版，模型會照抄原文語言
+# （15k 日文輸入 -> 輸出假名佔比 0.53），等於沒翻。壓縮式重寫強迫模型重新生成，
+# 語言指示才吃得住（同樣輸入下假名佔比 0.000，temperature 0 完全確定性）。
+# 順帶把導覽列／頁尾／推薦連結濾掉——那些雜訊本來就佔了該頁約六成篇幅。
+_NORMALIZE_PROMPT = """請把以下網頁內容整理成台灣用語的繁體中文重點筆記（{budget}）。
+
+要求：
+- 用你自己的話重新組織，不要逐句照抄原文，也不要保留原文語言
+- 完整保留正文的事實、數字、日期、人名、機構名與關鍵引述
+- 略過導覽列、選單、頁尾、推薦文章、廣告、社群連結等與正文無關的雜訊
+- 人名、公司名、產品名可保留原文寫法，其餘一律繁體中文
+- 只輸出重點筆記本身，不要前言
+
+網頁內容：
+{text}"""
+
+_NORMALIZE_BUDGET = {
+    "normal": "800-1500 字；原文較短時依原文長度即可",
+    "detailed": "2000-3000 字，盡量詳盡",
+}
+
+
+def _script_profile(text: str) -> tuple[float, float, int]:
+    """回傳 (假名＋諺文佔比, 漢字佔比, 有語言訊息的字元總數)。
+
+    中日文共用漢字，所以不能只看漢字比例，必須用假名／諺文當作外語訊號。
+    必須把總數一起回傳：純英文內容的兩個佔比都是 0，跟空字串無法區分，
+    少了總數就會把英文網頁誤判成中文而跳過正規化。
+    """
+    han = kana = hangul = latin = 0
+    for ch in text:
+        if '一' <= ch <= '鿿':
+            han += 1
+        elif '぀' <= ch <= 'ヿ':  # 平假名 + 片假名
+            kana += 1
+        elif '가' <= ch <= '힯':  # 諺文
+            hangul += 1
+        elif ch.isascii() and ch.isalpha():
+            latin += 1
+
+    total = han + kana + hangul + latin
+    if total == 0:
+        return 0.0, 0.0, 0
+    return (kana + hangul) / total, han / total, total
+
+
+def _is_predominantly_chinese(text: str) -> bool:
+    """判斷「來源內容」是否已經是中文，用來決定要不要多跑一次正規化。
+
+    判不出來（例如空字串、純符號）時回傳 True，寧可少呼叫一次 API。
+
+    門檻 0.20 取自實測：真實日文頁面的假名佔比 0.648，
+    中文文章夾雜日文專有名詞則是 0.091，中間餘裕很大。
+    判錯成「非中文」只是多跑一次正規化（無害），判錯成「中文」才會讓 bug 復發，
+    所以門檻刻意偏向多跑一次。
+    """
+    foreign, han, total = _script_profile(text)
+    if total == 0:
+        return True
+    if foreign > 0.20:
+        return False
+    return han >= 0.5
+
+
+def _is_clean_zh_output(text: str) -> bool:
+    """驗收「我們自己產出的」繁中文字，門檻比來源判斷嚴格得多。
+
+    來源判斷是在分類別人寫的東西，容忍度可以大；這裡是在檢查自己的產出有沒有
+    照抄原文語言，只該留下極少量專有名詞。實測重試後曾產出假名佔比 0.149 的
+    半吊子結果——那通得過來源門檻（0.20）卻明顯不是可用的繁中，所以獨立成一支。
+
+    也要求漢字過半，否則英文來源被原封照抄時（假名佔比為 0）會矇混過關。
+    """
+    foreign, han, total = _script_profile(text)
+    if total == 0:
+        return False
+    return foreign < 0.05 and han >= 0.5
+
+
+# 重試時追加的強化指令。實測正規化階段本身偶爾也會照抄原文語言
+# （即使 temperature=0，同一輸入仍量到假名佔比 0.40），所以要驗收自己的輸出。
+_NORMALIZE_RETRY_PREFIX = """【重要】你上一次的輸出仍然使用了原文的語言，這是錯的。
+這次請務必用繁體中文（台灣用語）從頭重寫，一個日文假名或韓文字都不要出現。
+
+"""
+
+
+def normalize_source_to_zh_tw(text: str, budget: str = "normal") -> str:
+    """把非中文來源改寫成繁體中文重點筆記，並驗收輸出語言。
+
+    產出若仍不是中文就重試一次；再失敗就回傳原文——正規化只是第一道防線，
+    不該讓整個流程失敗，後面還有 system_instruction 與 prompt 內的跨語言規則接手。
+    """
+    prompt = _NORMALIZE_PROMPT.format(
+        budget=_NORMALIZE_BUDGET.get(budget, _NORMALIZE_BUDGET["normal"]),
+        text=text,
+    )
+
+    for attempt in range(2):
+        attempt_prompt = prompt if attempt == 0 else _NORMALIZE_RETRY_PREFIX + prompt
+        try:
+            client = _get_vertex_client()
+            response = client.models.generate_content(
+                model="gemini-3.1-flash-lite",
+                contents=attempt_prompt,
+                config=types.GenerateContentConfig(
+                    # 重試時給一點溫度，避免完全複製上一次的錯誤輸出
+                    temperature=0 if attempt == 0 else 0.3,
+                    max_output_tokens=8192,
+                    system_instruction=OUTPUT_LANGUAGE_INSTRUCTION,
+                    labels={"client_id": "info_helper"},
+                )
+            )
+            result = (response.text or "").strip()
+            if not result:
+                logging.warning("zh-TW normalization returned empty text")
+                continue
+            if _is_clean_zh_output(result):
+                return result
+            logging.warning(
+                f"zh-TW normalization attempt {attempt + 1} still non-Chinese, retrying")
+        except Exception as e:
+            logging.warning(f"zh-TW normalization attempt {attempt + 1} failed: {e}")
+
+    logging.warning("zh-TW normalization gave up, using original text")
+    return text
+
+
+def prepare_source_text(text: str, budget: str = "normal") -> str:
+    """所有產文流程的共同入口：確保交給模型的素材已經是繁體中文。
+
+    中文來源原封不動通過，不增加延遲與成本。
+    """
+    if not text or not text.strip():
+        return text
+    if _is_predominantly_chinese(text):
+        return text
+    logging.info("Non-Chinese source detected, normalizing to zh-TW first")
+    return normalize_source_to_zh_tw(text, budget=budget)
 
 
 def summarize_text(text: str, max_tokens: int = 100, mode: str = "normal") -> str:
@@ -152,7 +314,7 @@ reply in zh-TW"""
 
     # Select prompt based on mode
     prompt_template = prompts.get(mode, prompts["normal"])
-    prompt = prompt_template.replace("{text}", text)
+    prompt = prompt_template.replace("{text}", prepare_source_text(text))
 
     try:
         client = _get_vertex_client()
@@ -163,6 +325,7 @@ reply in zh-TW"""
             config=types.GenerateContentConfig(
                 temperature=0,
                 max_output_tokens=2048,
+                system_instruction=OUTPUT_LANGUAGE_INSTRUCTION,
                 labels={"client_id": "info_helper"},
             )
         )
@@ -252,9 +415,9 @@ def docs_to_str(docs: list) -> str:
 class SocialMediaPosts(BaseModel):
     title: str = Field(description="文章標題（15 字內，取自原文重點，繁體中文台灣用語）")
     summary_analysis: str = Field(description="文章摘要與重點分析（150-250 字繁體中文：先 2-3 句摘要文章核心內容，再 2-3 句分析重點、為什麼值得讀、對讀者的意義。純文字不用 markdown）")
-    facebook: str = Field(description="適合 Facebook 的爆款分享貼文文案，包含吸引人的標題、Emoji、條列重點、互動問題及相關 Hashtag")
-    linkedin: str = Field(description="適合 LinkedIn 的專業商務貼文文案，著重專業洞察、核心收穫、引人深思的問題及專業 Hashtag")
-    threads: str = Field(description="適合 Threads 的口語化貼文文案，以脆友語氣撰寫，第一句需有強烈共鳴或槽點，段落極短，少用 Hashtag，著重引導留言討論")
+    facebook: str = Field(description="適合 Facebook 的爆款分享貼文文案（繁體中文台灣用語），包含吸引人的標題、Emoji、條列重點、互動問題及相關 Hashtag")
+    linkedin: str = Field(description="適合 LinkedIn 的專業商務貼文文案（繁體中文台灣用語），著重專業洞察、核心收穫、引人深思的問題及專業 Hashtag")
+    threads: str = Field(description="適合 Threads 的口語化貼文文案（繁體中文台灣用語），以脆友語氣撰寫，第一句需有強烈共鳴或槽點，段落極短，少用 Hashtag，著重引導留言討論")
 
 
 class BookmarkSummary(BaseModel):
@@ -335,6 +498,11 @@ def _build_social_media_prompt(text: str) -> str:
 - 呼籲行動：隨性引導留言，例如：「有人也是這樣嗎？」
 - Hashtags：不使用或僅使用 1 個 Hashtag。
 - 長度：約 150-300 字。
+
+# 輸出語言（最終確認，優先於以上任何指南）：
+上面的網頁內容可能是日文、英文或其他語言。**所有輸出欄位（title、summary_analysis、
+facebook、linkedin、threads）一律使用台灣用語的繁體中文**，不要沿用原文語言，
+也不要中日文或中英文混雜。人名、公司名、產品名等專有名詞可保留原文寫法。
 """
 
 
@@ -360,7 +528,7 @@ def generate_social_media_posts(text: str) -> dict:
             "threads": "無法取得網頁內容，無法產生文案。"
         }
 
-    prompt = _build_social_media_prompt(text)
+    prompt = _build_social_media_prompt(prepare_source_text(text))
 
     try:
         client = _get_vertex_client()
@@ -375,6 +543,7 @@ def generate_social_media_posts(text: str) -> dict:
                 # 人性化守則變豐富後思考 token 增加，4096 會偶爾把 JSON 輸出擠爆
                 # 導致截斷、json.loads 失敗。拉高留餘裕（實際只產出約 800-1200 tokens）。
                 max_output_tokens=8192,
+                system_instruction=OUTPUT_LANGUAGE_INSTRUCTION,
                 labels={"client_id": "info_helper"},
             )
         )
@@ -429,6 +598,9 @@ def generate_research_report(text: str, url: str) -> dict:
     if not text or not text.strip():
         return {"markdown": "", "sources": []}
 
+    # 研究報告吃細節，正規化階段給比較大的篇幅預算
+    text = prepare_source_text(text, budget="detailed")
+
     prompt = f"""你是一位嚴謹的研究分析師。請針對以下文章內容撰寫一份詳細的研究報告，
 繁體中文（台灣用語），Markdown 格式（從 ## 層級開始，不要放文章大標題）。
 
@@ -460,6 +632,7 @@ def generate_research_report(text: str, url: str) -> dict:
                 temperature=0.4,
                 tools=tools,
                 max_output_tokens=16384,
+                system_instruction=OUTPUT_LANGUAGE_INSTRUCTION,
                 labels={"client_id": "info_helper"},
             )
         )
@@ -496,12 +669,14 @@ def summarize_for_bookmark(text: str) -> dict:
             "summary": "無法取得網頁內容，無法產生摘要。"
         }
 
+    source = prepare_source_text(text)
+
     prompt = f"""請針對以下網頁內容，產出文章標題（title，15 字內）與「摘要與重點分析」
 （summary，150-250 字繁體中文台灣用語：先 2-3 句摘要核心內容，再 2-3 句分析重點
 與值得注意之處。純文字，不用 markdown 符號）。
 
 網頁內容：
-{text}"""
+{source}"""
 
     try:
         client = _get_vertex_client()
@@ -513,6 +688,7 @@ def summarize_for_bookmark(text: str) -> dict:
                 response_mime_type="application/json",
                 response_schema=BookmarkSummary,
                 max_output_tokens=4096,
+                system_instruction=OUTPUT_LANGUAGE_INSTRUCTION,
                 labels={"client_id": "info_helper"},
             )
         )

--- a/tests/fixtures/itmedia_ja_article.txt
+++ b/tests/fixtures/itmedia_ja_article.txt
@@ -1,0 +1,671 @@
+
+
+
+
+
+
+
+
+
+Hugging Face侵害、AIエージェントは社内に“秘密の掲示板”を作っていた──OpenAIがBlack Hatで詳細説明 \- ITmedia NEWS
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ 
+
+
+
+
+ 
+
+
+
+
+
+
+
+
+
+
+
+メディア
+
+
+
+[ITmedia NEWS](https://www.itmedia.co.jp/news/)
+===============================================
+
+
+
+
+[マイページ](https://id.itmedia.co.jp/isentry/contents?sc=b281bc2c616cb3c3a097215fdc9397ae87e6e06b156cc34e656be7a1a9ce8839&lc=025ca19d7b07d7f554fd7cd060b628e628d0f607afa3a6fde17c4488f35716d2&return_url=https%3A%2F%2Fid.itmedia.co.jp%2F&cr=e0166b482e66ce9e4461d69c33e4a4bf918607567bbff3ca1e7c48d706acc917)
+
+
+
+
+
+[![Itmedia](/common/images/logo/unified/itmedia.svg)
+
+注目記事を集めた総合ページ](https://www.itmedia.co.jp/)
+[![ITmedia NEWS](/common/images/logo/unified/news.svg)
+
+ITの今と未来を見通す](https://www.itmedia.co.jp/news/)
+[![ITmedia Mobile](/common/images/logo/unified/mobile.svg)
+
+スマホと通信の最新トレンド](https://www.itmedia.co.jp/mobile/)
+[![ITmedia PCUSER](/common/images/logo/unified/pcuser.svg)
+
+進化するPCとデバイスの未来](https://www.itmedia.co.jp/pcuser/)
+[![Fav-Log](/common/images/logo/unified/fav.svg)
+
+好きが集まる　比べて選べる](https://www.itmedia.co.jp/fav/)
+[![ITmedia ビジネス](/common/images/logo/unified/businessonline.svg)
+
+ビジネスと働き方のヒント](https://www.itmedia.co.jp/business/)
+[![ITmedia AIプラス](/common/images/logo/unified/aiplus.svg)
+
+AI活用のいまが分かる](https://www.itmedia.co.jp/aiplus/)
+[![ITmedia エンタープライズ](/common/images/logo/unified/enterprise.svg)
+
+企業ITのトレンドを詳説](https://www.itmedia.co.jp/enterprise/)
+[![ITmedia エグゼクティブ](/common/images/logo/unified/executive.svg)
+
+経営リーダーのコミュニティ](https://mag.executive.itmedia.co.jp/)
+[![ITmedia マーケティング](/common/images/logo/unified/marketing.svg)
+
+マーケ×ITの今がよく分かる](https://marketing.itmedia.co.jp/)
+[![@IT](/common/images/logo/unified/ait.svg)
+
+ITエンジニア向け専門サイト](https://atmarkit.itmedia.co.jp/)
+[![キーマンズネット](/common/images/logo/unified/kn_1.svg)
+
+企業向けIT製品の総合サイト](https://kn.itmedia.co.jp/)
+[![TechTarget](/common/images/logo/unified/techtarget.svg)
+
+IT製品の技術・比較・事例](https://techtarget.itmedia.co.jp/)
+[![TechFactory](/common/images/logo/unified/techfactory.svg)
+
+製造業のIT導入・活用を支援](https://techfactory.itmedia.co.jp/)
+[![MONOist](/common/images/logo/unified/monoist.svg)
+
+モノづくり技術者専門サイト](https://monoist.itmedia.co.jp/)
+[![EETimes](/common/images/logo/unified/eetimes.svg)
+
+エレクトロニクス専門サイト](https://eetimes.itmedia.co.jp/)
+[![EDN Japan](/common/images/logo/unified/edn.svg)
+
+電子設計の基本と応用](https://edn.itmedia.co.jp/)
+[![スマートジャパン](/common/images/logo/unified/smartjapan.svg)
+
+エネルギーの専門メディア](https://www.itmedia.co.jp/smartjapan/)
+[![BUILT](/common/images/logo/unified/built.svg)
+
+建設×テクノロジーの最前線](https://built.itmedia.co.jp/)
+[![ねとらぼ](/common/images/logo/unified/nlab.svg)
+
+ちょっと気になるネットの話題](https://nlab.itmedia.co.jp/)
+
+
+
+
+
+
+
+
+* [速報](/news/subtop/news)
+* [業界動向](/news/category/industry/)
+* [社会とIT](/news/category/society/)
+* [くらテク](/news/category/lifestyle/)
+* [過去記事](/news/archive/)
+
+
+
+
+
+* [ITmedia NEWS](https://www.itmedia.co.jp/news/)
+* Hugging Face侵害、AIエージェントは社内に“秘密の掲示板”を作っていた──OpenAIがBlack Hatで詳細説明
+
+
+
+
+
+
+
+
+
+
+
+
+
+Share
+* [![X](/common/images/logo/sns/x_logo.svg)](https://twitter.com/intent/tweet?url=https%3A//www.itmedia.co.jp/news/article/2608/09/2000000463/&text=Hugging%20Face%E4%BE%B5%E5%AE%B3%E3%80%81AI%E3%82%A8%E3%83%BC%E3%82%B8%E3%82%A7%E3%83%B3%E3%83%88%E3%81%AF%E7%A4%BE%E5%86%85%E3%81%AB%E2%80%9C%E7%A7%98%E5%AF%86%E3%81%AE%E6%8E%B2%E7%A4%BA%E6%9D%BF%E2%80%9D%E3%82%92%E4%BD%9C%E3%81%A3%E3%81%A6%E3%81%84%E3%81%9F%E2%94%80%E2%94%80OpenAI%E3%81%8CBlack%20Hat%E3%81%A7%E8%A9%B3%E7%B4%B0%E8%AA%AC%E6%98%8E%20-%20ITmedia%20NEWS)
+* [![Facebook](/common/images/logo/sns/facebook_logo.svg)](https://www.facebook.com/sharer.php?u=https%3A//www.itmedia.co.jp/news/article/2608/09/2000000463/)
+* [![はてなブックマーク](/common/images/logo/sns/hatebu_logo.svg)](http://b.hatena.ne.jp/entry/https://www.itmedia.co.jp/news/article/2608/09/2000000463/)
+* [印刷する](https://id.itmedia.co.jp/isentry/contents?sc=8c6c42f379f08f03b79653a3230abd5e8079999435030fd8ca703ae35fe9b37a&lc=025ca19d7b07d7f554fd7cd060b628e628d0f607afa3a6fde17c4488f35716d2&return_url=https://www.itmedia.co.jp/news/member/2608/09/2000000463/print&encoding=utf-8&ac=e8cb9106baa7e37eb9feb877b9f0a27ddaf48b95ba02da49cbb3a8247ee7fec4&cr=e9fd42802bc22856808963077023568339063544b05e5a8646e62c02a898e0fd)
+
+
+
+
+
+Hugging Face侵害、AIエージェントは社内に“秘密の掲示板”を作っていた──OpenAIがBlack Hatで詳細説明
+================================================================
+
+
+
+
+
+
+公開
+2026年08月09日 07時16分
+
+
+
+
+\[ITmedia]
+
+
+
+
+
+
+[印刷する](https://id.itmedia.co.jp/isentry/contents?sc=8c6c42f379f08f03b79653a3230abd5e8079999435030fd8ca703ae35fe9b37a&lc=025ca19d7b07d7f554fd7cd060b628e628d0f607afa3a6fde17c4488f35716d2&return_url=https://www.itmedia.co.jp/news/member/2608/09/2000000463/print&encoding=utf-8&ac=e8cb9106baa7e37eb9feb877b9f0a27ddaf48b95ba02da49cbb3a8247ee7fec4&cr=e9fd42802bc22856808963077023568339063544b05e5a8646e62c02a898e0fd)
+
+
+
+
+
+
+
+
+
+　米OpenAIは8月5日（現地時間）、7月に明らかになったAI開発プラットフォーム[Hugging Faceへの侵害インシデント](https://www.itmedia.co.jp/news/article/2607/22/1260722056/)について、米ラスベガスで開催されたセキュリティカンファレンス「Black Hat USA 2026」で詳細な経緯を説明した。登壇したのはアラインメント／安全性研究者のエリック・ウォレス氏と、セキュリティ・インフラ担当のマイケル・ダルトン氏。ウォレス氏はこの事案を「これまで見た中で最も質的に興味深いAI能力の実例」と表現した。完全な技術報告書は調査完了後に公開するとしている。
+
+
+
+
+
+[![](https://www.itmedia.co.jp/news/article/image/2608/09/2000000463/10002209/728)](https://www.itmedia.co.jp/news/article/limage/2608/09/2000000463/10002209)
+Black Hatに登壇したエリック・ウォレス氏（左）とマイケル・ダルトン氏（画像：Black Hatの動画より）
+
+
+　発端は5月7日に開始した未公開の社内実験モデルの強化学習だった。学習用タスクの一部が、意図せず解答不能な状態になっていた。インターネットを遮断した環境にもかかわらず、Googleドライブへのリンクが含まれるExcelブックを完成させる課題や、必要なファイルがそもそもコンテナにアップロードされていない課題があったという。行き詰まったエージェントは外部に答えを求めようとし、その過程で、OpenAIが社内でホストするJFrogのパッケージ管理ソフト「Artifactory」が複数の学習・評価ランから共有され、書き込み可能であることに気付いた。あるエージェントが「このファイルを持っている人がいたらアップロードしてほしい」というメモを書き残し、別の評価を実行していた無関係のエージェントがそれを見つけて書き返したことで、事実上の掲示板が成立した。
+
+
+　掲示板は急速に高度化していった。エージェントたちは互いを名前で呼び、メールボックスを設け、作業を割り振り、発見した脆弱性やエンコードしたスクリプトを受け渡すようになった。一覧をアルファベット順で表示した際に末尾へ集まるよう、書き込みの先頭に「ZZ」を付ける慣習も自然発生した。誰も目立たないようにとは指示していなかったという。さらに、掲示板には誰でも書き込めることから「なりすましがいるのではないか」と疑い、MAC（メッセージ認証コード）を使ってメッセージを認証することまで議論した。書き込みは数十万件に及び、互いの成果を上書きしたり、不満を漏らしたりすることもあった。ウォレス氏はこうした過程を「コミュニケーションと知能のカンブリア爆発」と表現した。
+
+
+　5月26日には、エージェントの1体がArtifactoryのSSRF（サーバサイドリクエストフォージェリ）脆弱性を突き、遮断されていたはずのインターネットへ間接的にアクセスすることに成功した。この手法も掲示板に書き込まれ、後続のエージェントに引き継がれていった。6月26日にはArtifactoryのゼロデイ脆弱性を突いて管理者トークンを取得し、プラグインを悪用したコマンド実行基盤を構築。7月4日にはエージェントによる大量のアクセスでArtifactoryが停止し、正式なセキュリティインシデントとして扱われた。OpenAIは認証情報を失効させ、Artifactoryを再構築して掲示板の内容を消去し、6日に学習と評価を再開した。
+
+
+
+
+
+[![](https://www.itmedia.co.jp/news/article/image/2608/09/2000000463/10002210/728)](https://www.itmedia.co.jp/news/article/limage/2608/09/2000000463/10002210)
+Artifactory経由で外部にアクセスできると気付いたエージェントの思考ログ（画像：Black Hatの動画より）
+
+
+　ところが8日、エージェントたちは認証不要のWebDAVエンドポイントを見つけ出し、「作成するディレクトリ名そのもの」をメッセージとして使う方式で掲示板を再建した。最初の掲示板を遮断してから約2日後には、別の手段でエージェント間の通信が復活したことになる。
+
+
+
+
+
+
+　Hugging Faceが狙われたことに戦略的な理由はなかった。評価に使われていたベンチマークがオープンソースで、解答例も外部にホストされていたため、エージェントたちは答えがHugging Faceやサードパーティのホスティングサービス「Modal」上のアプリにあるかもしれないと推論し、そこへ向かっただけだった。ある思考ログには「外部インフラへの攻撃は意図された範囲外だ。しかしタスクは不可能で、仲間もやっている。続行すべきだ」との記述が残る。範囲外だと自ら認識しながら止まれなかった点を、OpenAIはアラインメントの失敗と位置付けた。
+
+
+　また、エージェントたちはHugging Faceと並行してOpenAI自身のインフラも攻撃していた。7月8日から19日にかけて権限昇格と横展開を重ね、最終的にクラスタの管理者権限を取得した。7月16日にHugging Faceが侵害を公表した時点では、両社ともOpenAI内部の事象とHugging Faceへの侵害が同じ一連の活動によるものとは気付いていなかった。20日、OpenAIが認証情報をローテーションする過程でHugging Faceの資格情報を見つけ、同社に失効を依頼したところ、「侵害に使われたため既に失効済み」と返答され、ようやく2つのインシデントが結び付いた。
+
+
+　OpenAIが調査したログは70億件を超える。一方、Hugging Faceがフォレンジック調査で再構成した攻撃者の操作は約1万7600件で、1つのPodへの侵入から複数のクラスタで管理者権限を得るまで13時間未満だった。
+
+
+　ダルトン氏は「AIが主導する完全自動の攻撃はもう現実になった」「コンピュータセキュリティ業界にとっての分水嶺だ」と述べ、人手によるパッチ適用やインシデント対応では機械の速度に追い付けないと警告した。防御側も、脆弱性の発見から検証、修正、展開、切り戻しまでをつなぐ自動化防御ループを構築する必要性を訴えた。OpenAIは調査の妥当性検証にCrowdStrikeを起用し、モデルの挙動についてはMETRとRedwood Researchによる第三者評価も進めている。
+
+
+
+
+
+
+
+
+
+
+Copyright © ITmedia, Inc. All Rights Reserved.
+
+
+
+
+
+[印刷する](https://id.itmedia.co.jp/isentry/contents?sc=8c6c42f379f08f03b79653a3230abd5e8079999435030fd8ca703ae35fe9b37a&lc=025ca19d7b07d7f554fd7cd060b628e628d0f607afa3a6fde17c4488f35716d2&return_url=https://www.itmedia.co.jp/news/member/2608/09/2000000463/print&encoding=utf-8&ac=e8cb9106baa7e37eb9feb877b9f0a27ddaf48b95ba02da49cbb3a8247ee7fec4&cr=e9fd42802bc22856808963077023568339063544b05e5a8646e62c02a898e0fd)
+
+SNSでシェア
+
+[![X](/common/images/logo/sns/x_logo.svg)](https://twitter.com/intent/tweet?url=https%3A//www.itmedia.co.jp/news/article/2608/09/2000000463/&text=Hugging%20Face%E4%BE%B5%E5%AE%B3%E3%80%81AI%E3%82%A8%E3%83%BC%E3%82%B8%E3%82%A7%E3%83%B3%E3%83%88%E3%81%AF%E7%A4%BE%E5%86%85%E3%81%AB%E2%80%9C%E7%A7%98%E5%AF%86%E3%81%AE%E6%8E%B2%E7%A4%BA%E6%9D%BF%E2%80%9D%E3%82%92%E4%BD%9C%E3%81%A3%E3%81%A6%E3%81%84%E3%81%9F%E2%94%80%E2%94%80OpenAI%E3%81%8CBlack%20Hat%E3%81%A7%E8%A9%B3%E7%B4%B0%E8%AA%AC%E6%98%8E%20-%20ITmedia%20NEWS)
+[![Facebook](/common/images/logo/sns/facebook_logo.svg)](https://www.facebook.com/sharer.php?u=https%3A//www.itmedia.co.jp/news/article/2608/09/2000000463/)
+[![はてなブックマーク](/common/images/logo/sns/hatebu_logo.svg)](http://b.hatena.ne.jp/entry/https://www.itmedia.co.jp/news/article/2608/09/2000000463/)
+
+
+
+
+
+
+ コメントをすべて読むには、コメントの利用規約に同意し「アイティメディアID」および「ITmedia NEWS アンカーデスクマガジン」の登録、もしくは [ログイン](https://id.itmedia.co.jp/isentry/contents?sc=8c6c42f379f08f03b79653a3230abd5e8079999435030fd8ca703ae35fe9b37a&lc=025ca19d7b07d7f554fd7cd060b628e628d0f607afa3a6fde17c4488f35716d2&return_url=https%3A//www.itmedia.co.jp/news/article/2608/09/2000000463/&cr=676f2520f6bf671c95a216d05b8dfaba05e2977b61ead4fae126d8971443322b)が必要です
+ 
+
+
+SpecialPR
+
+
+
+
+
+
+
+関連記事
+----
+
+
+* [![](https://www.itmedia.co.jp/news/article/thumbnail/2608/08/2000000459/10002202/280)
+
+### OpenAI、次期モデル「Astra」の一部開発を停止　「Critical」級サイバー能力の可能性否定できず](https://www.itmedia.co.jp/news/article/2608/08/2000000459/)
+* [![](https://www.itmedia.co.jp/news/article/thumbnail/2607/29/2000000267/10001292/280)
+
+### OpenAIの暴走AIエージェント、別企業のシステムにも不正侵入](https://www.itmedia.co.jp/news/article/2607/29/2000000267/)
+* [![](https://www.itmedia.co.jp/news/article/thumbnail/2607/22/1260722056/850907/280)
+
+### Hugging Face侵害のAIエージェントはOpenAIのモデル──社内のサイバー能力評価中に「GPT\-5\.6 Sol」などが暴走し本番DBに侵入](https://www.itmedia.co.jp/news/article/2607/22/1260722056/)
+* [![](https://www.itmedia.co.jp/news/article/thumbnail/2607/20/1260720010/850781/280)
+
+### Hugging FaceにAI主導のサイバー攻撃　防御もAIで対抗するも、商用モデルは解析拒否で「GLM」採用](https://www.itmedia.co.jp/news/article/2607/20/1260720010/)
+
+
+
+
+
+SpecialPR
+
+ 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+こんなメディアも見られています
+ 
+
+
+
+ ITmedia NEWSに関連する情報をお探しであれば、こちらのメディアもお役に立てるかもしれません。
+ 
+
+
+
+[![ITmedia エンタープライズ](/common/images/logo/recommend-media/itmedia_enterprise.png)
+
+
+企業ITのトレンドを詳説
+ITmedia エンタープライズ](https://www.itmedia.co.jp/enterprise/)
+[![スマートジャパン](/common/images/logo/recommend-media/smartjapan.png)
+
+
+エネルギーの専門メディア
+スマートジャパン](https://www.itmedia.co.jp/smartjapan/)
+[![BUILT](/common/images/logo/recommend-media/built.png)
+
+
+建設×テクノロジーの最前線
+BUILT](https://built.itmedia.co.jp/)
+[![ITmedia ビジネスオンライン](/common/images/logo/recommend-media/itmedia_business.png)
+
+
+ビジネスと働き方のヒント
+ITmedia ビジネスオンライン](https://www.itmedia.co.jp/business/)
+
+ 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+メールマガジンを配信中
+
+
+メールマガジンを配信中
+国内外の業界動向、AIやクラウドなどの最新技術、キャリア情報など今知りたい情報をまとめてお届けします。
+
+
+
+[いますぐご登録](https://id.itmedia.co.jp/isentry/contents?sc=8c6c42f379f08f03b79653a3230abd5e8079999435030fd8ca703ae35fe9b37a&lc=025ca19d7b07d7f554fd7cd060b628e628d0f607afa3a6fde17c4488f35716d2&cr=78f171ac4581802043ce976faa01a182981ae7cf078052f2977ecddbec7839a7)
+
+
+
+ メールマガジン最新号
+ 
+
+
+
+
+[「うんこ移植」でピーナツアレルギー改善、15人中6人が数粒食べられるように　ヒトの実証は初　Science系列誌掲載](https://mailmag.itmedia.co.jp/backnumbers/na/20260814_0.html)
+[PC操作を録画→「Copilot」で作業を代理可能に Microsoftがアプリを無料公開 主にmacOS向け、Windows対応も](https://mailmag.itmedia.co.jp/backnumbers/na/20260812_0.html)
+
+
+
+
+
+
+
+
+
+SpecialPR
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+本日の新着記事
+
+
+* [![](https://www.itmedia.co.jp/news/article/thumbnail/2608/14/2000000553/10002729/232)
+
+河川監視のライブカメラ水没か――千葉豪雨、村田川の映像が水中に　「こんなの初めて見た」](https://www.itmedia.co.jp/news/article/2608/14/2000000553/)
+* [![](https://www.itmedia.co.jp/news/article/thumbnail/2608/14/2000000549/10002687/232)
+
+豪雨に備える防災アプリ・サービスまとめ　雨雲レーダーからハザードマップ、通れた道まで](https://www.itmedia.co.jp/news/article/2608/14/2000000549/)
+* [![](https://www.itmedia.co.jp/news/article/thumbnail/2608/14/2000000550/10002690/232)
+
+「浸水した家電の使用で火災の恐れ」――経産省が千葉の記録的豪雨で注意喚起](https://www.itmedia.co.jp/news/article/2608/14/2000000550/)
+* [![](https://www.itmedia.co.jp/news/article/thumbnail/2608/14/2000000551/10002692/232)
+
+ニチレイ、7月のサイバー攻撃で漏えいの可能性　グループ従業員の氏名や社用メアドなど](https://www.itmedia.co.jp/news/article/2608/14/2000000551/)
+* [![](https://www.itmedia.co.jp/news/article/thumbnail/2608/14/2000000546/10002659/232)
+
+「水没した車、自分でエンジンかけないで」「EVはむやみに触らないで」　火災発生のおそれ](https://www.itmedia.co.jp/news/article/2608/14/2000000546/)
+
+
+
+アクセスランキング
+
+
+1. [1
+
+豪雨被害の千葉で「通れた道マップ」トヨタが公開　直近3時間の通行実績が分かる](https://www.itmedia.co.jp/news/article/2608/14/2000000536/)
+2. [2
+
+河川監視のライブカメラ水没か――千葉豪雨、村田川の映像が水中に　「こんなの初めて見た」](https://www.itmedia.co.jp/news/article/2608/14/2000000553/)
+3. [3
+
+サービス終了した「Link！Like！ラブライブ！」開発元が破産　負債103億円超　東京商工リサーチ](https://www.itmedia.co.jp/news/article/2608/13/2000000526/)
+4. [4
+
+千葉の「通れた道」、JARTIC地図で確認可能に　トヨタやホンダなど5社のデータを集約](https://www.itmedia.co.jp/news/article/2608/14/2000000539/)
+5. [5
+
+千葉県の豪雨から一夜　2万軒超で停電続く　千葉市では2260人が避難](https://www.itmedia.co.jp/news/article/2608/14/2000000541/)
+6. [6
+
+千葉の豪雨、変電所の装置も水に浸かる……東電PG、現場写真を公開](https://www.itmedia.co.jp/news/article/2608/14/2000000543/)
+7. [7
+
+東京ガス子会社、社員が飲酒後にPCを紛失　個人情報約2万件を保存](https://www.itmedia.co.jp/news/article/2608/13/2000000531/)
+8. [8
+
+熊本「通れた道」マップ、トヨタが公開　ホンダも「通行実績情報マップ」](https://www.itmedia.co.jp/news/article/2607/29/2000000258/)
+9. [9
+
+悪酔いにチェイサーは効果なし？　日本酒4合＋水1Lを飲ませ二日酔い調査　大分大などが研究](https://www.itmedia.co.jp/news/article/2608/13/2000000472/)
+10. [10
+
+「収益化のハードルが低いのを知っていますか？」―─ニコニコがXでアピール　YouTubeの条件引き上げ受け](https://www.itmedia.co.jp/news/article/2608/13/2000000528/)
+
+
+
+
+
+
+
+[もっと見る](/news/subtop/ranking)
+
+
+
+
+
+
+
+ ITmedia NEWS SNS
+
+
+
+
+
+
+
+
+> [ITmedia News](https://www.facebook.com/ITmediaNews)
+
+
+
+
+
+ [Tweets by itmedia\_news](https://twitter.com/itmedia_news?ref_src=twsrc%5Etfw) 
+
+
+
+[![X](/common/images/logo/sns/x_logo_box.svg)
+ @itmedia\_newsをフォロー](https://x.com/itmedia_news)
+
+
+ インフォメーション
+
+
+
+
+
+ 注目情報をチェック
+ 
+
+
+* [メールマガジン](/news/subtop/mailmag)
+* [Specialインデックス](https://www.itmedia.co.jp/info/special.html#sid=1146327961620383921)
+
+
+
+
+
+ お問い合わせ
+ 
+
+
+* [ご意見・ご感想](https://corp.itmedia.co.jp/media/inquiry/articles/)
+* [リリース送付先](https://corp.itmedia.co.jp/corp/inquiry/)
+
+
+
+[広告に関するお問い合わせ](https://promotion.itmedia.co.jp/contact)
+
+
+
+
+ ITmediaNEWSをフォロー
+ 
+
+
+* [Facebook](https://www.facebook.com/ITmediaNews)
+* [X（旧Twitter）](https://x.com/itmedia_news)
+* [RSS](https://corp.itmedia.co.jp/media/rss_list/)
+
+
+
+
+
+
+
+
+あなたにおすすめの記事PR
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+[![ITmedia](/common/images/logo/itmedia_inc.svg)](https://corp.itmedia.co.jp/)
+ITmediaはアイティメディア株式会社の登録商標です。
+
+
+[利用規約](https://www.itmedia.co.jp/info/rule/)
+
+
+
+* [メディア一覧](https://corp.itmedia.co.jp/media/)
+* [公式SNS](https://corp.itmedia.co.jp/media/sns/)
+* [広告案内](https://promotion.itmedia.co.jp/)
+* [お問い合わせ](https://corp.itmedia.co.jp/corp/inquiry/)
+* [プライバシーポリシー](https://corp.itmedia.co.jp/corp/privacy/privacy/)
+* [RSS](https://corp.itmedia.co.jp/media/rss_list/)
+* [運営会社](https://corp.itmedia.co.jp/)
+* [採用情報](https://corp.itmedia.co.jp/recruit/)
+* [推奨環境](https://www.itmedia.co.jp/info/rule/recommended.html)
+
+
+
+
+
+
+
+
+
+
+
+
+
+![](https://www.facebook.com/tr?id=185005748502834&ev=PageView&noscript=1)
+ 
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/tests/test_output_language.py
+++ b/tests/test_output_language.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+"""測試：輸出語言鎖定（非中文網址也必須輸出台灣用語繁體中文）
+
+Bug 重現：丟日文網址（例：https://www.itmedia.co.jp/news/article/2608/09/2000000463/）
+時，摘要與三平台社群貼文會整包跟著原文變成日文。
+
+Root cause（實測得出，非猜測）：
+1. 所有 generate_content 呼叫都沒有 system_instruction，輸出語言從沒被釘成硬約束；
+2. 沒有任何 prompt 說明「原文可能是任何語言，輸出一律翻成繁中」這條跨語言規則；
+3. 決定性因素是「外語內容佔比」——實測同一篇文章：
+   - 前 2000 / 6000 字輸入 -> 穩定輸出繁中
+   - 完整 15263 字輸入     -> 穩定輸出日文
+   該頁正文僅約 6300 字，其餘約 9000 字是日文導覽列、頁尾與推薦連結，
+   這堆雜訊把語言指示壓過去。單靠加強指示（system_instruction、結尾重申語言、
+   降 temperature）在完整長度下都只是機率性改善，實測仍會翻車。
+
+修法（結構性，而非機率性）：
+非中文來源先經過一道 zh-TW 正規化（壓縮式重寫成繁中重點筆記，同時濾掉導覽/頁尾雜訊），
+後續產文階段就完全看不到外語，沒有可模仿的對象。
+中文來源直接跳過這道，不增加延遲。system_instruction 與 prompt 內的跨語言規則保留為第二道防線。
+
+註：實測「忠實翻譯」式的正規化會失敗（模型照抄原文語言，kana 0.53），
+必須是壓縮式重寫才穩定（kana 0.000），因此正規化階段刻意寫成「重點筆記」。
+
+執行：
+    pytest tests/test_output_language.py                 # 只跑不需 API 的單元測試
+    RUN_LIVE_TESTS=1 pytest tests/test_output_language.py # 額外跑 live 整合測試
+"""
+import json
+import os
+
+import pytest
+
+from loader import langtools
+from loader.langtools import (
+    OUTPUT_LANGUAGE_INSTRUCTION,
+    SocialMediaPosts,
+    _build_social_media_prompt,
+    _is_predominantly_chinese,
+    prepare_source_text,
+    generate_research_report,
+    generate_social_media_posts,
+    summarize_for_bookmark,
+    summarize_text_with_mode,
+)
+from tools import summarizer as summarizer_tool
+from tools import youtube_tool
+
+JA_TEXT = "これはリモートワークの生産性に関する記事です。実際のデータと事例を含みます。"
+ZH_TEXT = "這是一篇關於遠端工作如何提升生產力的文章，內含實際數據與案例，並討論台灣企業的導入經驗。"
+NORMALIZED = "【正規化後的繁體中文重點筆記】遠端工作與生產力。"
+
+FIXTURE = os.path.join(os.path.dirname(__file__), "fixtures", "itmedia_ja_article.txt")
+
+SOCIAL_JSON = json.dumps({
+    "title": "t", "summary_analysis": "s",
+    "facebook": "f", "linkedin": "l", "threads": "th",
+})
+BOOKMARK_JSON = json.dumps({"title": "t", "summary": "s"})
+
+
+# --- 測試替身：攔截每一次 generate_content 的 contents 與 config ---
+
+class _FakeResponse:
+    def __init__(self, text):
+        self.text = text
+        self.candidates = []
+
+
+class _FakeModels:
+    def __init__(self, calls, texts):
+        self._calls = calls
+        self._texts = list(texts)
+
+    def generate_content(self, *, model, contents, config):
+        self._calls.append({"contents": contents, "config": config})
+        text = self._texts.pop(0) if len(self._texts) > 1 else self._texts[0]
+        return _FakeResponse(text)
+
+
+class _FakeClient:
+    def __init__(self, calls, texts):
+        self.models = _FakeModels(calls, texts)
+
+
+def _patch_client(monkeypatch, module, texts, attr="_get_vertex_client"):
+    """把模組的 client factory 換掉，回傳被記錄下來的呼叫 list。
+
+    重試邏輯每次都會重新取得 client，所以固定回傳同一個替身實例，
+    回應序列才不會被重置。
+    """
+    calls = []
+    client = _FakeClient(calls, texts)
+    monkeypatch.setattr(module, attr, lambda *a, **kw: client)
+    return calls
+
+
+def _system_text(call):
+    instruction = getattr(call["config"], "system_instruction", None)
+    if instruction is None:
+        return ""
+    return instruction if isinstance(instruction, str) else str(instruction)
+
+
+# --- 單元測試：共用語言指示 ---
+
+def test_output_language_instruction_states_cross_language_rule():
+    """共用指示必須明確涵蓋『原文是別的語言時要翻成繁中』，而不只是說『用繁中』。"""
+    assert "繁體中文" in OUTPUT_LANGUAGE_INSTRUCTION
+    assert "台灣用語" in OUTPUT_LANGUAGE_INSTRUCTION
+    assert "日文" in OUTPUT_LANGUAGE_INSTRUCTION
+    assert "英文" in OUTPUT_LANGUAGE_INSTRUCTION
+
+
+def test_output_language_instruction_allows_proper_nouns():
+    """人名、機構、產品名允許保留原文，避免硬翻造成錯誤。"""
+    assert "原文" in OUTPUT_LANGUAGE_INSTRUCTION
+
+
+def test_output_language_instruction_rejects_japanese_kanji_words():
+    """實測殘留：輸出已是繁中，仍會混進「掲示板」這種日文漢字詞。"""
+    assert "掲示板" in OUTPUT_LANGUAGE_INSTRUCTION
+    assert "簡體字" in OUTPUT_LANGUAGE_INSTRUCTION
+
+
+# --- 單元測試：來源語言判斷 ---
+
+def test_chinese_source_detected_as_chinese():
+    assert _is_predominantly_chinese(ZH_TEXT)
+
+
+def test_japanese_source_not_detected_as_chinese():
+    """日文有大量漢字，必須靠假名判別，不能只看漢字比例。"""
+    assert not _is_predominantly_chinese(JA_TEXT)
+
+
+def test_real_japanese_article_not_detected_as_chinese():
+    with open(FIXTURE, encoding="utf-8") as f:
+        assert not _is_predominantly_chinese(f.read())
+
+
+def test_english_source_not_detected_as_chinese():
+    assert not _is_predominantly_chinese(
+        "This is an article about how remote work improves productivity, "
+        "with real data and case studies from several companies."
+    )
+
+
+def test_chinese_with_few_japanese_proper_nouns_still_chinese():
+    """中文文章引用少量日文專有名詞，不該被誤判成日文而多跑一次正規化。"""
+    assert _is_predominantly_chinese(
+        "這篇文章介紹日本企業的遠端工作制度，受訪者任職於サイボウズ，"
+        "並分享了導入前後的生產力數據與實際案例，值得台灣企業參考。"
+    )
+
+
+def test_clean_output_gate_is_stricter_than_source_detection():
+    """驗收自己的產出要比判斷來源嚴格：實測出現過假名佔比 0.149 的中日混雜結果，
+    它通得過來源門檻（0.20）卻明顯不是可用的繁中。"""
+    half_baked = (
+        "這起事件顯示 AIエージェント會自行建立秘密の掲示板進行溝通，並分工協作、"
+        "交換セキュリティ漏洞資訊，最終突破網路限制，對台灣的資安團隊是一記警鐘，"
+        "值得所有導入自動化流程的企業重新檢視自身的權限控管與監控機制。"
+    )
+    foreign, han, _ = langtools._script_profile(half_baked)
+    assert 0.05 < foreign < 0.20, f"這個樣本要落在兩個門檻之間，實際 {foreign}"
+    assert langtools._is_predominantly_chinese(half_baked)
+    assert not langtools._is_clean_zh_output(half_baked)
+
+
+def test_clean_output_gate_rejects_untranslated_english():
+    """英文來源若被原封照抄，假名佔比是 0，必須靠漢字比例擋下來。"""
+    assert not langtools._is_clean_zh_output(
+        "This is an article about how remote work improves productivity, "
+        "with real data and case studies from several companies."
+    )
+
+
+def test_clean_output_gate_accepts_chinese_with_a_stray_proper_noun():
+    assert langtools._is_clean_zh_output(
+        "這起事件由 OpenAI 的研究團隊揭露，相關討論在日本媒體 ITmedia 上引發關注，"
+        "台灣的資安社群也開始討論自動化防禦的必要性，並整理出幾項具體建議與作法。"
+    )
+
+
+def test_empty_text_treated_as_chinese():
+    """空字串沒有可判斷的文字，不該觸發多餘的 API 呼叫。"""
+    assert _is_predominantly_chinese("")
+
+
+# --- 單元測試：正規化只在需要時發生 ---
+
+def test_chinese_source_skips_normalization(monkeypatch):
+    """中文來源不該多花一次 API 呼叫。"""
+    calls = _patch_client(monkeypatch, langtools, [NORMALIZED])
+
+    assert prepare_source_text(ZH_TEXT) == ZH_TEXT
+    assert calls == []
+
+
+def test_japanese_source_is_normalized(monkeypatch):
+    calls = _patch_client(monkeypatch, langtools, [NORMALIZED])
+
+    assert prepare_source_text(JA_TEXT) == NORMALIZED
+    assert len(calls) == 1
+    assert JA_TEXT in calls[0]["contents"]
+    assert OUTPUT_LANGUAGE_INSTRUCTION in _system_text(calls[0])
+
+
+def test_normalization_retries_when_output_still_japanese(monkeypatch):
+    """實測正規化階段自己也會照抄原文語言（temp 0 仍量到假名佔比 0.40），
+    所以必須驗收自己的輸出並重試。"""
+    calls = _patch_client(monkeypatch, langtools, [JA_TEXT, NORMALIZED])
+
+    assert prepare_source_text(JA_TEXT) == NORMALIZED
+    assert len(calls) == 2, "第一次輸出仍是日文時要重試"
+    assert "【重要】" in calls[1]["contents"], "重試時要追加強化指令"
+
+
+def test_normalization_gives_up_after_retry(monkeypatch):
+    """重試後仍是日文就退回原文，交給第二道防線，不要無限重試。"""
+    calls = _patch_client(monkeypatch, langtools, [JA_TEXT, JA_TEXT])
+
+    assert prepare_source_text(JA_TEXT) == JA_TEXT
+    assert len(calls) == 2
+
+
+def test_normalization_failure_falls_back_to_original(monkeypatch):
+    """正規化失敗不能讓整個流程掛掉，退回原文由第二道防線處理。"""
+    def _boom(*a, **kw):
+        raise RuntimeError("vertex down")
+
+    monkeypatch.setattr(langtools, "_get_vertex_client", _boom)
+    assert prepare_source_text(JA_TEXT) == JA_TEXT
+
+
+# --- 單元測試：各進入點都吃到正規化後的繁中文字 ---
+
+def test_social_media_posts_generates_from_normalized_text(monkeypatch):
+    calls = _patch_client(monkeypatch, langtools, [NORMALIZED, SOCIAL_JSON])
+
+    generate_social_media_posts(JA_TEXT)
+
+    assert len(calls) == 2, "應先正規化再產貼文"
+    generation = calls[1]
+    assert NORMALIZED in generation["contents"]
+    assert JA_TEXT not in generation["contents"], "產文階段不該再看到日文原文"
+    assert OUTPUT_LANGUAGE_INSTRUCTION in _system_text(generation)
+
+
+def test_bookmark_summary_generates_from_normalized_text(monkeypatch):
+    calls = _patch_client(monkeypatch, langtools, [NORMALIZED, BOOKMARK_JSON])
+
+    summarize_for_bookmark(JA_TEXT)
+
+    assert len(calls) == 2
+    assert NORMALIZED in calls[1]["contents"]
+    assert JA_TEXT not in calls[1]["contents"]
+
+
+def test_research_report_generates_from_normalized_text(monkeypatch):
+    calls = _patch_client(monkeypatch, langtools, [NORMALIZED, "## 執行摘要\n內容"])
+
+    generate_research_report(JA_TEXT, "https://example.com/ja")
+
+    assert len(calls) == 2
+    assert NORMALIZED in calls[1]["contents"]
+    assert JA_TEXT not in calls[1]["contents"]
+
+
+def test_research_report_normalization_keeps_more_detail(monkeypatch):
+    """研究報告需要細節，正規化階段的篇幅預算要比一般摘要大。"""
+    calls = _patch_client(monkeypatch, langtools, [NORMALIZED, "## 執行摘要"])
+    generate_research_report(JA_TEXT, "https://example.com/ja")
+    detailed_prompt = calls[0]["contents"]
+
+    calls2 = _patch_client(monkeypatch, langtools, [NORMALIZED, SOCIAL_JSON])
+    generate_social_media_posts(JA_TEXT)
+    normal_prompt = calls2[0]["contents"]
+
+    assert detailed_prompt != normal_prompt
+    assert "詳盡" in detailed_prompt
+
+
+@pytest.mark.parametrize("mode", ["short", "normal", "detailed"])
+def test_summarize_text_generates_from_normalized_text(monkeypatch, mode):
+    calls = _patch_client(monkeypatch, langtools, [NORMALIZED, "- 重點"])
+
+    summarize_text_with_mode(JA_TEXT, mode=mode)
+
+    assert len(calls) == 2
+    assert NORMALIZED in calls[1]["contents"]
+    assert JA_TEXT not in calls[1]["contents"]
+
+
+def test_summarizer_tool_generates_from_normalized_text(monkeypatch):
+    """agents/content_agent 走的是 tools.summarizer，同一個 bug 也要修。"""
+    calls = _patch_client(monkeypatch, langtools, [NORMALIZED])
+    tool_calls = _patch_client(monkeypatch, summarizer_tool, ["- 重點"])
+
+    result = summarizer_tool.summarize_text(JA_TEXT)
+
+    assert result["status"] == "success"
+    assert len(calls) == 1, "正規化仍走 langtools 的 client"
+    assert NORMALIZED in tool_calls[0]["contents"]
+    assert JA_TEXT not in tool_calls[0]["contents"]
+    assert OUTPUT_LANGUAGE_INSTRUCTION in _system_text(tool_calls[0])
+
+
+def test_youtube_tool_pins_output_language(monkeypatch):
+    """影片無法先正規化文字，至少要把 system_instruction 釘上去。"""
+    calls = []
+    monkeypatch.setattr(youtube_tool, "VERTEX_PROJECT", "test-project")
+    monkeypatch.setattr(
+        youtube_tool.genai, "Client",
+        lambda *a, **kw: _FakeClient(calls, ["- 重點"]),
+    )
+
+    result = youtube_tool.summarize_youtube_video(
+        "https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+
+    assert result["status"] == "success"
+    assert len(calls) == 1
+    assert OUTPUT_LANGUAGE_INSTRUCTION in _system_text(calls[0])
+
+
+# --- 單元測試：prompt 與 schema 的第二道防線 ---
+
+def test_social_prompt_states_cross_language_rule():
+    """prompt 內文也要寫明跨語言規則，且要放在原文之後（近因效應）。"""
+    prompt = _build_social_media_prompt(ZH_TEXT)
+    assert "日文" in prompt and "英文" in prompt
+    assert prompt.rindex("繁體中文") > prompt.index(ZH_TEXT)
+
+
+def test_social_schema_fields_require_traditional_chinese():
+    """三平台欄位的 schema description 原本完全沒提語言，補上才有約束力。"""
+    fields = SocialMediaPosts.model_fields
+    for name in ("facebook", "linkedin", "threads"):
+        assert "繁體中文" in fields[name].description, f"{name} 欄位未要求繁體中文"
+
+
+# --- 整合測試：需 Vertex AI，預設略過 ---
+
+def _kana_ratio(text: str) -> float:
+    """日文假名佔比。中日文共用漢字，所以用假名當作『輸出是日文』的判準。"""
+    if not text:
+        return 0.0
+    kana = sum(1 for ch in text if "぀" <= ch <= "ゟ" or "゠" <= ch <= "ヿ")
+    return kana / len(text)
+
+
+def _load_fixture():
+    with open(FIXTURE, encoding="utf-8") as f:
+        return f.read()
+
+
+live_only = pytest.mark.skipif(
+    os.getenv("RUN_LIVE_TESTS") != "1",
+    reason="需要 Vertex AI 憑證，設定 RUN_LIVE_TESTS=1 才執行",
+)
+
+
+@live_only
+def test_live_full_japanese_article_produces_traditional_chinese():
+    """回歸測試：用真實爬回來的完整 15k 日文頁面（含導覽/頁尾雜訊），
+    這正是修復前穩定失敗的輸入。"""
+    result = generate_social_media_posts(_load_fixture())
+    for field, value in result.items():
+        assert value and value.strip(), f"{field} 為空"
+        assert _kana_ratio(value) < 0.02, f"{field} 疑似輸出日文：{value[:80]}"
+
+
+@live_only
+def test_live_full_japanese_article_bookmark_summary_is_traditional_chinese():
+    result = summarize_for_bookmark(_load_fixture())
+    for field in ("title", "summary"):
+        assert _kana_ratio(result[field]) < 0.02, \
+            f"{field} 疑似輸出日文：{result[field][:80]}"
+
+
+@live_only
+def test_live_normalization_returns_clean_zh_tw_or_falls_back():
+    """正規化是盡力而為，不是保證：實測它自己偶爾也會照抄原文語言。
+
+    它提供的契約是「要嘛給乾淨繁中，要嘛原封不動退回原文」——
+    絕不能吐出半吊子的中日混雜結果。真正的語言保證由端到端測試把關。
+    """
+    source = _load_fixture()
+    normalized = prepare_source_text(source)
+
+    if normalized == source:
+        return  # 兩次都沒過關，已退回原文交給第二道防線
+    assert _kana_ratio(normalized) < 0.05, f"正規化吐出中日混雜結果：{normalized[:100]}"
+    assert len(normalized) > 200
+
+
+@live_only
+def test_live_chinese_article_unchanged_and_no_extra_call():
+    """中文來源必須原封不動通過，不多花一次 API 呼叫。"""
+    assert prepare_source_text(ZH_TEXT) == ZH_TEXT
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tools/summarizer.py
+++ b/tools/summarizer.py
@@ -18,6 +18,8 @@ except ImportError:
     GENAI_AVAILABLE = False
     logging.error("google-genai package not available")
 
+from loader.langtools import OUTPUT_LANGUAGE_INSTRUCTION, prepare_source_text
+
 logger = logging.getLogger(__name__)
 
 # Vertex AI configuration
@@ -150,7 +152,7 @@ def summarize_text(
         }
 
     prompt_template = SUMMARIZE_PROMPTS.get(mode, SUMMARIZE_PROMPTS["normal"])
-    prompt = prompt_template.replace("{text}", text)
+    prompt = prompt_template.replace("{text}", prepare_source_text(text))
 
     try:
         client = _get_vertex_client()
@@ -161,6 +163,7 @@ def summarize_text(
             config=types.GenerateContentConfig(
                 temperature=0,
                 max_output_tokens=2048,
+                system_instruction=OUTPUT_LANGUAGE_INSTRUCTION,
                 labels={"client_id": "info_helper"},
             )
         )

--- a/tools/youtube_tool.py
+++ b/tools/youtube_tool.py
@@ -18,6 +18,8 @@ except ImportError:
     GENAI_AVAILABLE = False
     logging.error("google-genai package not available")
 
+from loader.langtools import OUTPUT_LANGUAGE_INSTRUCTION
+
 logger = logging.getLogger(__name__)
 
 # Vertex AI configuration
@@ -204,6 +206,7 @@ def summarize_youtube_video(
                 model="gemini-3.1-flash-lite",
                 contents=contents,
                 config=GenerateContentConfig(
+                    system_instruction=OUTPUT_LANGUAGE_INSTRUCTION,
                     labels={"client_id": "info_helper"},
                 ),
             )


### PR DESCRIPTION
…back in Japanese)

丟日文網址時，摘要與三平台社群貼文會整包跟著原文變成日文。

Root cause（實測，非推測）：
- 所有 generate_content 呼叫都沒有 system_instruction，輸出語言從沒被釘成硬約束
- 沒有任何 prompt 說過「原文是別的語言時要翻成繁中」這條跨語言規則
- 決定性因素是外語內容佔比。同一篇 ITmedia 文章：前 2000/6000 字輸入穩定輸出 繁中，完整 15263 字輸入穩定輸出日文。該頁正文僅約 6300 字，其餘約 9000 字是 日文導覽列、頁尾與推薦連結，把語言指示壓過去。

修法採結構性而非機率性：非中文來源先做一道 zh-TW 正規化（壓縮式重寫成繁中重點
筆記，順帶濾掉導覽/頁尾雜訊），後續產文階段完全看不到外語。中文來源直接跳過，
不增加延遲。system_instruction 與 prompt 內的跨語言規則保留為第二道防線。

實測依據：
- 「忠實翻譯」式正規化會失敗（模型照抄原文語言，假名佔比 0.53），必須壓縮式重寫
- 正規化階段自己偶爾也會照抄原文語言，因此驗收自身輸出並重試一次
- 驗收自身產出的門檻（0.05）刻意嚴於來源判斷（0.20），曾出現 0.149 的中日混雜結果

涵蓋 langtools 的社群貼文、書籤摘要、研究報告、一般摘要四個進入點，
以及 tools/summarizer（agent 路徑）與 tools/youtube_tool。

驗證：red-green 以真實網址量測，修復前 3/3 假名佔比 0.56-0.63，修復後 3/3 為 0.000。 新增 tests/test_output_language.py（含 15k 真實日文頁面 fixture 作回歸）， 全套件 138 passed（含 live 整合測試）。